### PR TITLE
fix data race from stats_handler.go

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
@@ -195,8 +195,8 @@ func (c *config) handleRPC(ctx context.Context, rs stats.RPCStats) {
 
 		metricAttrs = append(metricAttrs, rpcStatusAttr)
 		c.rpcDuration.Record(wctx, float64(rs.EndTime.Sub(rs.BeginTime)), metric.WithAttributes(metricAttrs...))
-		c.rpcRequestsPerRPC.Record(wctx, atomic.LoadInt64(gctx.messagesReceived), metric.WithAttributes(metricAttrs...))
-		c.rpcResponsesPerRPC.Record(wctx, atomic.LoadInt64(gctx.messagesSent), metric.WithAttributes(metricAttrs...))
+		c.rpcRequestsPerRPC.Record(wctx, atomic.LoadInt64(&gctx.messagesReceived), metric.WithAttributes(metricAttrs...))
+		c.rpcResponsesPerRPC.Record(wctx, atomic.LoadInt64(&gctx.messagesSent), metric.WithAttributes(metricAttrs...))
 
 	default:
 		return

--- a/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
@@ -195,8 +195,8 @@ func (c *config) handleRPC(ctx context.Context, rs stats.RPCStats) {
 
 		metricAttrs = append(metricAttrs, rpcStatusAttr)
 		c.rpcDuration.Record(wctx, float64(rs.EndTime.Sub(rs.BeginTime)), metric.WithAttributes(metricAttrs...))
-		c.rpcRequestsPerRPC.Record(wctx, gctx.messagesReceived, metric.WithAttributes(metricAttrs...))
-		c.rpcResponsesPerRPC.Record(wctx, gctx.messagesSent, metric.WithAttributes(metricAttrs...))
+		c.rpcRequestsPerRPC.Record(wctx, atomic.LoadInt64(gctx.messagesReceived), metric.WithAttributes(metricAttrs...))
+		c.rpcResponsesPerRPC.Record(wctx, atomic.LoadInt64(gctx.messagesSent), metric.WithAttributes(metricAttrs...))
 
 	default:
 		return


### PR DESCRIPTION
```
WARNING: DATA RACE
Read at 0x00c000bef1d8 by goroutine 890:
  go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc.(*config).handleRPC()
      /go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0/stats_handler.go:199 +0x190b
  go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc.(*clientHandler).HandleRPC()
      /go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0/stats_handler.go:124 +0x65
  google.golang.org/grpc.(*csAttempt).finish()
      /go/pkg/mod/google.golang.org/grpc@v1.59.0/stream.go:1171 +0x650
  google.golang.org/grpc.(*clientStream).finish()
      /go/pkg/mod/google.golang.org/grpc@v1.59.0/stream.go:988 +0x34b
  google.golang.org/grpc.(*clientStream).RecvMsg()
      /go/pkg/mod/google.golang.org/grpc@v1.59.0/stream.go:940 +0x2d2
  github.com/prodvana/prodvana-public/go/prodvana-sdk/proto/prodvana/agent.(*agentInteractionProxyAPIServerClient).Recv()
      /code/go-sdk/proto/prodvana/agent/agent_interaction_grpc.pb.go:181 +0x67
  prodvana/grpc/connwrapper.ConnectConnAndStreamingServer[...].func2.2()
      grpc/connwrapper/conn.go:141 +0xbc
```
